### PR TITLE
Points management based on labs solved & reviewed counters, fix line endings of scripts in Docker for Windows 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,67 @@
+# Git Line Ending Configuration for Cross-Platform Development
+# This ensures consistent line endings across Windows, macOS, and Linux
+
+# Default behavior: Auto-convert line endings based on platform
+* text=auto
+
+# Shell scripts must always use LF (Unix line endings) for Linux containers
+*.sh text eol=lf
+
+# Python files should use LF for consistency across platforms
+*.py text eol=lf
+
+# Configuration files should use LF for consistency
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.conf text eol=lf
+*.config text eol=lf
+*.properties text eol=lf
+
+# Java files should use LF for consistency
+*.java text eol=lf
+*.gradle text eol=lf
+gradlew text eol=lf
+
+# Go files should use LF
+*.go text eol=lf
+
+# Docker files should use LF
+Dockerfile* text eol=lf
+*.dockerfile text eol=lf
+
+# Protocol buffer files should use LF
+*.proto text eol=lf
+
+# Web files should use LF for consistency
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.md text eol=lf
+
+# SQL files should use LF
+*.sql text eol=lf
+
+# Windows specific files should use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files should not be modified
+*.jar binary
+*.pdf binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.zip binary
+*.tar.gz binary
+*.faiss binary
+*.pkl binary
+
+# IDE and editor files
+.vscode/* text eol=lf
+.idea/* text eol=lf

--- a/docker/Dockerfile.labs-service
+++ b/docker/Dockerfile.labs-service
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc \
     postgresql-client \
+    dos2unix \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements file
@@ -20,7 +21,7 @@ COPY services/labs-service/app/ /app/
 
 # Copy wait script
 COPY services/labs-service/scripts/wait-for-postgres.sh /usr/local/bin/wait-for-postgres.sh
-RUN chmod +x /usr/local/bin/wait-for-postgres.sh
+RUN dos2unix /usr/local/bin/wait-for-postgres.sh && chmod +x /usr/local/bin/wait-for-postgres.sh
 
 # Create __init__.py files to make directories Python packages
 RUN touch proto/__init__.py utils/__init__.py

--- a/docker/Dockerfile.ml-service
+++ b/docker/Dockerfile.ml-service
@@ -5,6 +5,8 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
+    dos2unix \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy ML service requirements
@@ -18,7 +20,7 @@ COPY ml/ /app/ml/
 
 # Copy and make startup script executable
 COPY ml/startup.sh /app/startup.sh
-RUN chmod +x /app/startup.sh
+RUN dos2unix /app/startup.sh && chmod +x /app/startup.sh
 
 # Create necessary directories
 RUN mkdir -p /app/models

--- a/services/api-gateway/src/main/proto/auth_service.proto
+++ b/services/api-gateway/src/main/proto/auth_service.proto
@@ -32,6 +32,9 @@ message UserInfo {
   string last_name = 4;
   string role = 5;
   string email = 6;
+  int32 labs_solved = 7;
+  int32 labs_reviewed = 8;
+  int32 balance = 9;
 }
 
 // Health check request

--- a/services/api-gateway/src/main/proto/users_service.proto
+++ b/services/api-gateway/src/main/proto/users_service.proto
@@ -44,6 +44,13 @@ service UsersService {
   // Delete a user (for rollback in case of transaction failures)
   rpc DeleteUser (DeleteUserRequest) returns (DeleteUserResponse) {}
 
+  // Points system methods
+  // Increment labs solved counter and deduct points
+  rpc IncrementLabsSolved (IncrementLabsSolvedRequest) returns (OperationResponse) {}
+  
+  // Increment labs reviewed counter and add points
+  rpc IncrementLabsReviewed (IncrementLabsReviewedRequest) returns (OperationResponse) {}
+
   // Health check endpoint
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckResponse) {}
 }
@@ -67,6 +74,9 @@ message UserInfo {
   string last_name = 4;
   string role = 5;
   string email = 6;
+  int32 labs_solved = 7;
+  int32 labs_reviewed = 8;
+  int32 balance = 9;
 }
 
 // Request to update a user's profile
@@ -156,6 +166,23 @@ message CreateUserRequest {
   string email = 4;
   string role = 5;
   string password = 6;
+}
+
+// Points system messages
+// Request to increment labs solved counter
+message IncrementLabsSolvedRequest {
+  int64 user_id = 1;
+}
+
+// Request to increment labs reviewed counter
+message IncrementLabsReviewedRequest {
+  int64 user_id = 1;
+}
+
+// Generic operation response
+message OperationResponse {
+  bool success = 1;
+  string message = 2;
 }
 
 // Health check response

--- a/services/auth-service/AUTH_API_DOCUMENTATION.md
+++ b/services/auth-service/AUTH_API_DOCUMENTATION.md
@@ -36,7 +36,10 @@
     "firstName": "John",
     "lastName": "Doe",
     "email": "johndoe@example.com",
-    "role": "ROLE_USER"
+    "role": "ROLE_USER",
+    "labsSolved": 0,
+    "labsReviewed": 0,
+    "balance": 10
   }
 }
 ```
@@ -117,7 +120,10 @@
     "firstName": "John",
     "lastName": "Doe",
     "email": "johndoe@example.com",
-    "role": "ROLE_USER"
+    "role": "ROLE_USER",
+    "labsSolved": 0,
+    "labsReviewed": 0,
+    "balance": 10
   }
 }
 ```
@@ -195,7 +201,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
     "firstName": "John",
     "lastName": "Doe",
     "email": "johndoe@example.com",
-    "role": "ROLE_USER"
+    "role": "ROLE_USER",
+    "labsSolved": 3,
+    "labsReviewed": 2,
+    "balance": 45
   },
   "status": "ACTIVE"
 }
@@ -242,7 +251,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
     "firstName": "Jane",
     "lastName": "Smith",
     "email": "jane.smith@example.com",
-    "role": "ROLE_USER"
+    "role": "ROLE_USER",
+    "labsSolved": 3,
+    "labsReviewed": 2,
+    "balance": 45
   },
   "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
   "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -263,7 +275,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
     "firstName": "Jane",
     "lastName": "Smith",
     "email": "jane.smith@example.com",
-    "role": "ROLE_USER"
+    "role": "ROLE_USER",
+    "labsSolved": 3,
+    "labsReviewed": 2,
+    "balance": 45
   },
   "accessToken": null,
   "refreshToken": null,

--- a/services/auth-service/AUTH_README.md
+++ b/services/auth-service/AUTH_README.md
@@ -96,6 +96,8 @@ The auth-service heavily relies on users-service gRPC endpoints:
 - `UpdateUserLastLogin`: For tracking login times
 - `CheckUsernameExists`: For username availability validation
 - `CheckEmailExists`: For email availability validation
+- `IncrementLabsSolved`: For updating user points when labs are solved (used by labs-service)
+- `IncrementLabsReviewed`: For updating user points when labs are reviewed (used by labs-service)
 
 ### gRPC Client Configuration
 

--- a/services/auth-service/src/main/java/olsh/backend/authservice/dto/UserInfo.java
+++ b/services/auth-service/src/main/java/olsh/backend/authservice/dto/UserInfo.java
@@ -29,4 +29,13 @@ public class UserInfo {
     
     @Schema(description = "Email address", example = "john.doe@example.com")
     private String email;
+
+    @Schema(description = "Number of labs solved by the user", example = "5")
+    private Integer labsSolved;
+
+    @Schema(description = "Number of labs reviewed by the user", example = "3")
+    private Integer labsReviewed;
+
+    @Schema(description = "User's current points balance", example = "40")
+    private Integer balance;
 }

--- a/services/auth-service/src/main/java/olsh/backend/authservice/grpc/AuthServiceGrpcImpl.java
+++ b/services/auth-service/src/main/java/olsh/backend/authservice/grpc/AuthServiceGrpcImpl.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 public class AuthServiceGrpcImpl extends AuthServiceGrpc.AuthServiceImplBase {
 
     private final AuthenticationService authenticationService;
-
+    
     @Override
     public void validateToken(ValidateTokenRequest request, StreamObserver<ValidateTokenResponse> responseObserver) {
         log.debug("gRPC token validation request");
@@ -46,14 +46,7 @@ public class AuthServiceGrpcImpl extends AuthServiceGrpc.AuthServiceImplBase {
             
             if (serviceResponse.getUserInfo() != null) {
                 olsh.backend.authservice.dto.UserInfo userInfo = serviceResponse.getUserInfo();
-                UserInfo grpcUserInfo = UserInfo.newBuilder()
-                    .setUserId(userInfo.getUserId())
-                    .setUsername(userInfo.getUsername())
-                    .setFirstName(userInfo.getFirstName() != null ? userInfo.getFirstName() : "")
-                    .setLastName(userInfo.getLastName() != null ? userInfo.getLastName() : "")
-                    .setRole(userInfo.getRole() != null ? userInfo.getRole() : "")
-                    .setEmail(userInfo.getEmail() != null ? userInfo.getEmail() : "")
-                    .build();
+                UserInfo grpcUserInfo = buildGrpcUserInfo(userInfo);
                 responseBuilder.setUserInfo(grpcUserInfo);
             }
             
@@ -105,5 +98,43 @@ public class AuthServiceGrpcImpl extends AuthServiceGrpc.AuthServiceImplBase {
             responseObserver.onNext(errorResponse);
             responseObserver.onCompleted();
         }
+    }
+
+    /**
+     * Converts DTO UserInfo to protobuf UserInfo
+     */
+    private UserInfo buildGrpcUserInfo(olsh.backend.authservice.dto.UserInfo userInfo) {
+        UserInfo.Builder builder = UserInfo.newBuilder()
+            .setUserId(userInfo.getUserId());
+        
+        // Only set string fields if they're not null (protobuf default is empty string)
+        if (userInfo.getUsername() != null) {
+            builder.setUsername(userInfo.getUsername());
+        }
+        if (userInfo.getFirstName() != null) {
+            builder.setFirstName(userInfo.getFirstName());
+        }
+        if (userInfo.getLastName() != null) {
+            builder.setLastName(userInfo.getLastName());
+        }
+        if (userInfo.getRole() != null) {
+            builder.setRole(userInfo.getRole());
+        }
+        if (userInfo.getEmail() != null) {
+            builder.setEmail(userInfo.getEmail());
+        }
+        
+        // Only set integer fields if they're not null (protobuf default is 0)
+        if (userInfo.getLabsSolved() != null) {
+            builder.setLabsSolved(userInfo.getLabsSolved());
+        }
+        if (userInfo.getLabsReviewed() != null) {
+            builder.setLabsReviewed(userInfo.getLabsReviewed());
+        }
+        if (userInfo.getBalance() != null) {
+            builder.setBalance(userInfo.getBalance());
+        }
+        
+        return builder.build();
     }
 } 

--- a/services/auth-service/src/main/java/olsh/backend/authservice/service/UserProfileService.java
+++ b/services/auth-service/src/main/java/olsh/backend/authservice/service/UserProfileService.java
@@ -14,8 +14,7 @@ import olsh.backend.authservice.dto.UserProfileResponseWithUserInfo;
 @Service
 @RequiredArgsConstructor
 public class UserProfileService {
-
-    private final UserService userService;
+    
     private final UsersServiceClient usersServiceClient;
 
     public UserProfileResponseWithUserInfo getUserProfileWithUserInfo(String username) {
@@ -37,6 +36,9 @@ public class UserProfileService {
                 .lastName(usersResponse.getUserInfo().getLastName())
                 .role(userInfo.getRole())
                 .email(usersResponse.getUserInfo().getEmail())
+                .labsSolved(usersResponse.getUserInfo().getLabsSolved())
+                .labsReviewed(usersResponse.getUserInfo().getLabsReviewed())
+                .balance(usersResponse.getUserInfo().getBalance())
                 .build();
                 
             return UserProfileResponseWithUserInfo.builder()
@@ -59,6 +61,9 @@ public class UserProfileService {
                 .lastName(response.getUserInfo().getLastName())
                 .role(response.getUserInfo().getRole())
                 .email(response.getUserInfo().getEmail())
+                .labsSolved(response.getUserInfo().getLabsSolved())
+                .labsReviewed(response.getUserInfo().getLabsReviewed())
+                .balance(response.getUserInfo().getBalance())
                 .build();
         } catch (Exception e) {
             log.error("Error getting user info from users-service for ID: {}", userId, e);
@@ -80,6 +85,9 @@ public class UserProfileService {
                 .lastName(response.getUserInfo().getLastName())
                 .role(response.getUserInfo().getRole())
                 .email(response.getUserInfo().getEmail())
+                .labsSolved(response.getUserInfo().getLabsSolved())
+                .labsReviewed(response.getUserInfo().getLabsReviewed())
+                .balance(response.getUserInfo().getBalance())
                 .build();
         } catch (Exception e) {
             log.error("Error finding user by email in users-service: {}", email, e);

--- a/services/auth-service/src/main/proto/auth_service.proto
+++ b/services/auth-service/src/main/proto/auth_service.proto
@@ -35,6 +35,9 @@ message UserInfo {
   string last_name = 4;
   string role = 5;
   string email = 6;
+  int32 labs_solved = 7;
+  int32 labs_reviewed = 8;
+  int32 balance = 9;
 }
 
 // Health check request

--- a/services/auth-service/src/main/proto/users_service.proto
+++ b/services/auth-service/src/main/proto/users_service.proto
@@ -40,9 +40,16 @@ service UsersService {
 
   // Create a new user profile (for use during registration)
   rpc CreateUser (CreateUserRequest) returns (UserProfileResponse) {}
-  
+
   // Delete a user (for rollback in case of transaction failures)
   rpc DeleteUser (DeleteUserRequest) returns (DeleteUserResponse) {}
+
+  // Points system methods
+  // Increment labs solved counter and deduct points
+  rpc IncrementLabsSolved (IncrementLabsSolvedRequest) returns (OperationResponse) {}
+  
+  // Increment labs reviewed counter and add points
+  rpc IncrementLabsReviewed (IncrementLabsReviewedRequest) returns (OperationResponse) {}
 
   // Health check endpoint
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckResponse) {}
@@ -67,6 +74,9 @@ message UserInfo {
   string last_name = 4;
   string role = 5;
   string email = 6;
+  int32 labs_solved = 7;
+  int32 labs_reviewed = 8;
+  int32 balance = 9;
 }
 
 // Request to update a user's profile
@@ -156,6 +166,23 @@ message CreateUserRequest {
   string email = 4;
   string role = 5;
   string password = 6;
+}
+
+// Points system messages
+// Request to increment labs solved counter
+message IncrementLabsSolvedRequest {
+  int64 user_id = 1;
+}
+
+// Request to increment labs reviewed counter
+message IncrementLabsReviewedRequest {
+  int64 user_id = 1;
+}
+
+// Generic operation response
+message OperationResponse {
+  bool success = 1;
+  string message = 2;
 }
 
 // Health check response

--- a/services/users-service/.env.example
+++ b/services/users-service/.env.example
@@ -1,24 +1,18 @@
-# Users Service Environment Variables
-# Copy this file to .env and update the values as needed
+SPRING_PROFILES_ACTIVE=dev
 
-# Database Configuration
 DB_URL=jdbc:postgresql://localhost:5432/users_service
 DB_USERNAME=postgres
-DB_PASSWORD=your_database_password
+DB_PASSWORD=postgres
 
-# gRPC Server Configuration
+HIBERNATE_DDL_AUTO=create-drop
+SHOW_SQL=false
+
 GRPC_PORT=9093
-
-# External Service Configuration (for potential future use)
 AUTH_SERVICE_HOST=localhost
 AUTH_SERVICE_PORT=8383
 
-# JPA/Hibernate Configuration
-HIBERNATE_DDL_AUTO=create-drop
-SHOW_SQL=true
+POINTS_MULTIPLIER_REVIEW=3
+POINTS_BASE_COST=1
+INITIAL_BALANCE=10
 
-# Logging Configuration
-LOG_LEVEL=INFO
-
-# Spring Profile
-SPRING_PROFILES_ACTIVE=dev
+LOG_LEVEL=INFO 

--- a/services/users-service/src/main/java/olsh/backend/usersservice/UsersServiceApplication.java
+++ b/services/users-service/src/main/java/olsh/backend/usersservice/UsersServiceApplication.java
@@ -2,8 +2,12 @@ package olsh.backend.usersservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import olsh.backend.usersservice.config.PointsConfig;
 
 @SpringBootApplication
+@EnableConfigurationProperties(PointsConfig.class)
 public class UsersServiceApplication {
 
     public static void main(String[] args) {

--- a/services/users-service/src/main/java/olsh/backend/usersservice/config/PointsConfig.java
+++ b/services/users-service/src/main/java/olsh/backend/usersservice/config/PointsConfig.java
@@ -1,0 +1,33 @@
+package olsh.backend.usersservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Configuration
+@ConfigurationProperties(prefix = "points")
+@Getter
+@Setter
+public class PointsConfig {
+    
+    /**
+     * Multiplier for review rewards (k)
+     * User gets k * base-cost points for reviewing
+     */
+    private int multiplierReview = 3;
+    
+    /**
+     * Base points cost/reward (n)
+     * User pays n points to solve a lab
+     * Base reward amount that gets multiplied for reviews
+     */
+    private int baseCost = 1;
+    
+    /**
+     * Initial balance for new users (m)
+     * Starting points when user registers
+     */
+    private int initialBalance = 10;
+} 

--- a/services/users-service/src/main/java/olsh/backend/usersservice/entity/User.java
+++ b/services/users-service/src/main/java/olsh/backend/usersservice/entity/User.java
@@ -1,6 +1,12 @@
 package olsh.backend.usersservice.entity;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,12 +22,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.List;
 
 @Entity
 @Getter
@@ -60,6 +60,19 @@ public class User implements UserDetails {
 
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
+
+    // Points system fields
+    @Column(name = "labs_solved", nullable = false)
+    @Builder.Default
+    private Integer labsSolved = 0;
+
+    @Column(name = "labs_reviewed", nullable = false)
+    @Builder.Default
+    private Integer labsReviewed = 0;
+
+    @Column(name = "balance", nullable = false)
+    @Builder.Default
+    private Integer balance = 10; // Will be set from configuration
 
     @PrePersist
     protected void onCreate() {

--- a/services/users-service/src/main/java/olsh/backend/usersservice/exception/InsufficientBalanceException.java
+++ b/services/users-service/src/main/java/olsh/backend/usersservice/exception/InsufficientBalanceException.java
@@ -1,0 +1,7 @@
+package olsh.backend.usersservice.exception;
+
+public class InsufficientBalanceException extends RuntimeException {
+    public InsufficientBalanceException(String message) {
+        super(message);
+    }
+} 

--- a/services/users-service/src/main/java/olsh/backend/usersservice/grpc/UsersServiceGrpcImpl.java
+++ b/services/users-service/src/main/java/olsh/backend/usersservice/grpc/UsersServiceGrpcImpl.java
@@ -13,6 +13,9 @@ import com.olsh.users.proto.GetUserInfoRequest;
 import com.olsh.users.proto.GetUserProfileRequest;
 import com.olsh.users.proto.HealthCheckRequest;
 import com.olsh.users.proto.HealthCheckResponse;
+import com.olsh.users.proto.IncrementLabsReviewedRequest;
+import com.olsh.users.proto.IncrementLabsSolvedRequest;
+import com.olsh.users.proto.OperationResponse;
 import com.olsh.users.proto.SearchUsersRequest;
 import com.olsh.users.proto.SearchUsersResponse;
 import com.olsh.users.proto.UpdatePasswordRequest;
@@ -349,20 +352,53 @@ public class UsersServiceGrpcImpl extends UsersServiceGrpc.UsersServiceImplBase 
             
             DeleteUserResponse response = DeleteUserResponse.newBuilder()
                 .setSuccess(success)
-                .setMessage(success ? 
-                    "User deleted successfully" : 
-                    "User deletion failed or user not found")
+                .setMessage(success ? "User deleted successfully" : "Failed to delete user")
                 .build();
                 
             responseObserver.onNext(response);
             responseObserver.onCompleted();
+        } catch (NotFoundException e) {
+            log.error("User not found with ID: {}", request.getUserId(), e);
+            responseObserver.onError(io.grpc.Status.NOT_FOUND
+                                         .withDescription("User not found with ID: " + request.getUserId())
+                                         .asException());
         } catch (Exception e) {
             log.error("Error deleting user with ID: {}", request.getUserId(), e);
             responseObserver.onError(io.grpc.Status.INTERNAL
-                                         .withDescription(
-                                             "Internal error deleting user: " + e.getMessage())
+                                         .withDescription("Internal server error: " + e.getMessage())
                                          .asException());
         }
     }
 
+    @Override
+    public void incrementLabsSolved(IncrementLabsSolvedRequest request,
+                                   StreamObserver<OperationResponse> responseObserver) {
+        try {
+            log.info("Received IncrementLabsSolved request for user ID: {}", request.getUserId());
+            OperationResponse response = userService.incrementLabsSolved(request);
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error incrementing labs solved for user ID: {}", request.getUserId(), e);
+            responseObserver.onError(io.grpc.Status.INTERNAL
+                                         .withDescription("Internal server error: " + e.getMessage())
+                                         .asException());
+        }
+    }
+
+    @Override
+    public void incrementLabsReviewed(IncrementLabsReviewedRequest request,
+                                     StreamObserver<OperationResponse> responseObserver) {
+        try {
+            log.info("Received IncrementLabsReviewed request for user ID: {}", request.getUserId());
+            OperationResponse response = userService.incrementLabsReviewed(request);
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("Error incrementing labs reviewed for user ID: {}", request.getUserId(), e);
+            responseObserver.onError(io.grpc.Status.INTERNAL
+                                         .withDescription("Internal server error: " + e.getMessage())
+                                         .asException());
+        }
+    }
 }

--- a/services/users-service/src/main/java/olsh/backend/usersservice/service/UserStatsService.java
+++ b/services/users-service/src/main/java/olsh/backend/usersservice/service/UserStatsService.java
@@ -1,0 +1,69 @@
+package olsh.backend.usersservice.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import olsh.backend.usersservice.config.PointsConfig;
+import olsh.backend.usersservice.entity.User;
+import olsh.backend.usersservice.exception.InsufficientBalanceException;
+import olsh.backend.usersservice.exception.NotFoundException;
+import olsh.backend.usersservice.repository.UserRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserStatsService {
+
+    private final UserRepository userRepository;
+    private final PointsConfig pointsConfig;
+
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
+    public void incrementLabsSolved(Long userId) {
+        log.debug("Incrementing labs solved for user ID: {}", userId);
+        
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException("User not found with ID: " + userId));
+        
+        int baseCost = pointsConfig.getBaseCost();
+        
+        // Check if user has sufficient balance
+        if (user.getBalance() < baseCost) {
+            log.warn("Insufficient balance for user ID: {}. Required: {}, Available: {}", 
+                     userId, baseCost, user.getBalance());
+            throw new InsufficientBalanceException(
+                String.format("Insufficient balance. Required: %d points, Available: %d points", 
+                             baseCost, user.getBalance()));
+        }
+        
+        // Increment counter and deduct points atomically
+        user.setLabsSolved(user.getLabsSolved() + 1);
+        user.setBalance(user.getBalance() - baseCost);
+        
+        userRepository.save(user);
+        
+        log.info("Successfully incremented labs solved for user ID: {}. New count: {}, New balance: {}", 
+                 userId, user.getLabsSolved(), user.getBalance());
+    }
+    
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
+    public void incrementLabsReviewed(Long userId) {
+        log.debug("Incrementing labs reviewed for user ID: {}", userId);
+        
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException("User not found with ID: " + userId));
+        
+        int rewardPoints = pointsConfig.getMultiplierReview() * pointsConfig.getBaseCost();
+        
+        // Increment counter and add reward points atomically
+        user.setLabsReviewed(user.getLabsReviewed() + 1);
+        user.setBalance(user.getBalance() + rewardPoints);
+        
+        userRepository.save(user);
+        
+        log.info("Successfully incremented labs reviewed for user ID: {}. New count: {}, New balance: {}, Reward: {} points", 
+                 userId, user.getLabsReviewed(), user.getBalance(), rewardPoints);
+    }
+} 

--- a/services/users-service/src/main/proto/users_service.proto
+++ b/services/users-service/src/main/proto/users_service.proto
@@ -44,6 +44,13 @@ service UsersService {
   // Delete a user (for rollback in case of transaction failures)
   rpc DeleteUser (DeleteUserRequest) returns (DeleteUserResponse) {}
 
+  // Points system methods
+  // Increment labs solved counter and deduct points
+  rpc IncrementLabsSolved (IncrementLabsSolvedRequest) returns (OperationResponse) {}
+  
+  // Increment labs reviewed counter and add points
+  rpc IncrementLabsReviewed (IncrementLabsReviewedRequest) returns (OperationResponse) {}
+
   // Health check endpoint
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckResponse) {}
 }
@@ -67,6 +74,9 @@ message UserInfo {
   string last_name = 4;
   string role = 5;
   string email = 6;
+  int32 labs_solved = 7;
+  int32 labs_reviewed = 8;
+  int32 balance = 9;
 }
 
 // Request to update a user's profile
@@ -156,6 +166,23 @@ message CreateUserRequest {
   string email = 4;
   string role = 5;
   string password = 6;
+}
+
+// Points system messages
+// Request to increment labs solved counter
+message IncrementLabsSolvedRequest {
+  int64 user_id = 1;
+}
+
+// Request to increment labs reviewed counter
+message IncrementLabsReviewedRequest {
+  int64 user_id = 1;
+}
+
+// Generic operation response
+message OperationResponse {
+  bool success = 1;
+  string message = 2;
 }
 
 // Health check response

--- a/services/users-service/src/main/resources/application.yml
+++ b/services/users-service/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
       host: ${AUTH_SERVICE_HOST:localhost}
       port: ${AUTH_SERVICE_PORT:8383}
 
+# Points system configuration
+points:
+  multiplier-review: ${POINTS_MULTIPLIER_REVIEW:3}  # k - multiplier for review rewards
+  base-cost: ${POINTS_BASE_COST:1}                  # n - base points cost/reward
+  initial-balance: ${INITIAL_BALANCE:10}            # m - initial balance for new users
+
 logging:
   level:
     olsh.backend.usersservice: ${LOG_LEVEL:INFO}

--- a/services/users-service/src/test/java/olsh/backend/usersservice/grpc/UsersServiceGrpcImplTest.java
+++ b/services/users-service/src/test/java/olsh/backend/usersservice/grpc/UsersServiceGrpcImplTest.java
@@ -19,7 +19,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/services/users-service/src/test/java/olsh/backend/usersservice/service/UserStatsServiceTest.java
+++ b/services/users-service/src/test/java/olsh/backend/usersservice/service/UserStatsServiceTest.java
@@ -1,0 +1,391 @@
+package olsh.backend.usersservice.service;
+
+import olsh.backend.usersservice.config.PointsConfig;
+import olsh.backend.usersservice.entity.Role;
+import olsh.backend.usersservice.entity.User;
+import olsh.backend.usersservice.exception.InsufficientBalanceException;
+import olsh.backend.usersservice.exception.NotFoundException;
+import olsh.backend.usersservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserStatsService Tests")
+class UserStatsServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PointsConfig pointsConfig;
+
+    @InjectMocks
+    private UserStatsService userStatsService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+            .id(1L)
+            .username("testuser")
+            .email("test@example.com")
+            .firstName("Test")
+            .lastName("User")
+            .role(Role.ROLE_USER)
+            .password("hashedpassword")
+            .labsSolved(5)
+            .labsReviewed(3)
+            .balance(10)
+            .createdAt(LocalDateTime.now())
+            .build();
+    }
+
+    // === Labs Solved Increment Tests ===
+
+    @Nested
+    @DisplayName("Increment Labs Solved Tests")
+    class IncrementLabsSolvedTests {
+
+        @Test
+        @DisplayName("Should increment labs solved and deduct balance when sufficient funds")
+        void incrementLabsSolved_WithSufficientBalance_ShouldIncrementCountAndDeductPoints() {
+            // Given
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsSolved(1L);
+
+            // Then
+            assertThat(testUser.getLabsSolved()).isEqualTo(6); // 5 + 1
+            assertThat(testUser.getBalance()).isEqualTo(9); // 10 - 1
+            verify(userRepository).findById(1L);
+            verify(pointsConfig).getBaseCost();
+            verify(userRepository).save(testUser);
+            verifyNoMoreInteractions(userRepository, pointsConfig);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "0, 1, false", // Exactly zero balance, cost 1
+            "0, 1, false", // Insufficient by 1 (same as zero for cost 1)
+            "1, 1, true",  // Exactly sufficient
+            "5, 1, true", // More than sufficient
+            "100, 10, true" // Much more than sufficient
+        })
+        @DisplayName("Should handle various balance scenarios correctly")
+        void incrementLabsSolved_WithVariousBalanceScenarios_ShouldHandleCorrectly(
+                int initialBalance, int baseCost, boolean shouldSucceed) {
+            // Given
+            testUser.setBalance(initialBalance);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(baseCost);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            if (shouldSucceed) {
+                // When
+                userStatsService.incrementLabsSolved(1L);
+
+                // Then
+                assertThat(testUser.getLabsSolved()).isEqualTo(6); // Original 5 + 1
+                assertThat(testUser.getBalance()).isEqualTo(initialBalance - baseCost);
+                verify(userRepository).save(testUser);
+            } else {
+                // When & Then
+                assertThatThrownBy(() -> userStatsService.incrementLabsSolved(1L))
+                    .isInstanceOf(InsufficientBalanceException.class)
+                    .hasMessageContaining("Insufficient balance")
+                    .hasMessageContaining("Required: " + baseCost)
+                    .hasMessageContaining("Available: " + initialBalance);
+                
+                // Verify no changes made
+                assertThat(testUser.getLabsSolved()).isEqualTo(5); // Unchanged
+                assertThat(testUser.getBalance()).isEqualTo(initialBalance); // Unchanged
+                verify(userRepository, never()).save(any(User.class));
+            }
+        }
+
+        @Test
+        @DisplayName("Should handle edge case of exact balance match")
+        void incrementLabsSolved_WithExactBalanceMatch_ShouldSucceed() {
+            // Given
+            testUser.setBalance(1); // Exactly the cost
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsSolved(1L);
+
+            // Then
+            assertThat(testUser.getLabsSolved()).isEqualTo(6);
+            assertThat(testUser.getBalance()).isEqualTo(0); // Should be exactly zero
+            verify(userRepository).save(testUser);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when user does not exist")
+        void incrementLabsSolved_WithNonExistentUser_ShouldThrowNotFoundException() {
+            // Given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> userStatsService.incrementLabsSolved(999L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("User not found with ID: 999");
+            
+            verify(userRepository).findById(999L);
+            verify(userRepository, never()).save(any(User.class));
+            verifyNoInteractions(pointsConfig);
+        }
+
+        @ValueSource(ints = {1, 2, 3, 5, 10})
+        @ParameterizedTest
+        @DisplayName("Should work correctly with different cost configurations")
+        void incrementLabsSolved_WithDifferentCosts_ShouldDeductCorrectAmount(int cost) {
+            // Given
+            testUser.setBalance(50); // Ensure sufficient balance
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(cost);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsSolved(1L);
+
+            // Then
+            assertThat(testUser.getLabsSolved()).isEqualTo(6);
+            assertThat(testUser.getBalance()).isEqualTo(50 - cost);
+            verify(userRepository).save(testUser);
+        }
+    }
+
+    // === Labs Reviewed Increment Tests ===
+
+    @Nested
+    @DisplayName("Increment Labs Reviewed Tests")
+    class IncrementLabsReviewedTests {
+
+        @Test
+        @DisplayName("Should increment labs reviewed and add reward points")
+        void incrementLabsReviewed_WithValidUser_ShouldIncrementCountAndAddReward() {
+            // Given
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getMultiplierReview()).thenReturn(3);
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsReviewed(1L);
+
+            // Then
+            assertThat(testUser.getLabsReviewed()).isEqualTo(4); // 3 + 1
+            assertThat(testUser.getBalance()).isEqualTo(13); // 10 + (3 * 1)
+            verify(userRepository).findById(1L);
+            verify(pointsConfig).getMultiplierReview();
+            verify(pointsConfig).getBaseCost();
+            verify(userRepository).save(testUser);
+            verifyNoMoreInteractions(userRepository, pointsConfig);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "1, 1, 1",   // k=1, n=1, reward=1
+            "3, 1, 3",   // k=3, n=1, reward=3 (default config)
+            "2, 2, 4",   // k=2, n=2, reward=4
+            "5, 1, 5",   // k=5, n=1, reward=5
+            "4, 2, 8"    // k=4, n=2, reward=8
+        })
+        @DisplayName("Should calculate reward correctly with different multiplier and cost configurations")
+        void incrementLabsReviewed_WithDifferentConfigurations_ShouldCalculateRewardCorrectly(
+                int multiplier, int baseCost, int expectedReward) {
+            // Given
+            int initialBalance = testUser.getBalance();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getMultiplierReview()).thenReturn(multiplier);
+            when(pointsConfig.getBaseCost()).thenReturn(baseCost);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsReviewed(1L);
+
+            // Then
+            assertThat(testUser.getLabsReviewed()).isEqualTo(4); // 3 + 1
+            assertThat(testUser.getBalance()).isEqualTo(initialBalance + expectedReward);
+            verify(userRepository).save(testUser);
+        }
+
+        @Test
+        @DisplayName("Should handle maximum integer values without overflow")
+        void incrementLabsReviewed_WithLargeValues_ShouldHandleCorrectly() {
+            // Given
+            testUser.setBalance(Integer.MAX_VALUE - 100); // Near max value
+            testUser.setLabsReviewed(Integer.MAX_VALUE - 1); // Near max value
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getMultiplierReview()).thenReturn(3);
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsReviewed(1L);
+
+            // Then
+            assertThat(testUser.getLabsReviewed()).isEqualTo(Integer.MAX_VALUE);
+            assertThat(testUser.getBalance()).isEqualTo(Integer.MAX_VALUE - 97); // Original + 3 reward
+            verify(userRepository).save(testUser);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when user does not exist")
+        void incrementLabsReviewed_WithNonExistentUser_ShouldThrowNotFoundException() {
+            // Given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> userStatsService.incrementLabsReviewed(999L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("User not found with ID: 999");
+            
+            verify(userRepository).findById(999L);
+            verify(userRepository, never()).save(any(User.class));
+            verifyNoInteractions(pointsConfig);
+        }
+
+        @Test
+        @DisplayName("Should work with zero reward configuration")
+        void incrementLabsReviewed_WithZeroReward_ShouldOnlyIncrementCounter() {
+            // Given
+            int initialBalance = testUser.getBalance();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getMultiplierReview()).thenReturn(0);
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When
+            userStatsService.incrementLabsReviewed(1L);
+
+            // Then
+            assertThat(testUser.getLabsReviewed()).isEqualTo(4); // Incremented
+            assertThat(testUser.getBalance()).isEqualTo(initialBalance); // Unchanged
+            verify(userRepository).save(testUser);
+        }
+    }
+
+    // === Edge Cases and Error Scenarios ===
+
+    @Nested
+    @DisplayName("Error Scenarios and Edge Cases")
+    class ErrorScenariosTests {
+
+        @Test
+        @DisplayName("Should handle null user ID gracefully")
+        void incrementLabsSolved_WithNullUserId_ShouldThrowAppropriateException() {
+            // When & Then
+            assertThatThrownBy(() -> userStatsService.incrementLabsSolved(null))
+                .isInstanceOf(Exception.class); // Repository will throw appropriate exception
+        }
+
+        @Test
+        @DisplayName("Should handle database save failure gracefully")
+        void incrementLabsSolved_WithDatabaseSaveFailure_ShouldPropagateException() {
+            // Given
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenThrow(new RuntimeException("Database error"));
+
+            // When & Then
+            assertThatThrownBy(() -> userStatsService.incrementLabsSolved(1L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Database error");
+            
+            // Verify the user object was modified before save attempt
+            assertThat(testUser.getLabsSolved()).isEqualTo(6);
+            assertThat(testUser.getBalance()).isEqualTo(9);
+        }
+
+        @Test
+        @DisplayName("Should maintain transaction isolation requirements")
+        void incrementMethods_ShouldUseCorrectTransactionSettings() {
+            // This test verifies that the methods are annotated correctly
+            // The actual transaction behavior would be tested in integration tests
+            
+            // Given
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(pointsConfig.getMultiplierReview()).thenReturn(3);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When - These should be atomic operations
+            userStatsService.incrementLabsSolved(1L);
+            userStatsService.incrementLabsReviewed(1L);
+
+            // Then - Verify both operations completed
+            verify(userRepository, times(2)).save(testUser);
+        }
+    }
+
+    // === Multiple Operations Tests ===
+
+    @Nested
+    @DisplayName("Multiple Operations Tests")
+    class MultipleOperationsTests {
+
+        @Test
+        @DisplayName("Should handle multiple consecutive solve operations")
+        void incrementLabsSolved_MultipleOperations_ShouldAccumulateCorrectly() {
+            // Given
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When - Perform multiple operations
+            userStatsService.incrementLabsSolved(1L);
+            userStatsService.incrementLabsSolved(1L);
+            userStatsService.incrementLabsSolved(1L);
+
+            // Then
+            assertThat(testUser.getLabsSolved()).isEqualTo(8); // 5 + 3
+            assertThat(testUser.getBalance()).isEqualTo(7); // 10 - (3 * 1)
+            verify(userRepository, times(3)).save(testUser);
+        }
+
+        @Test
+        @DisplayName("Should handle mixed solve and review operations")
+        void incrementOperations_MixedOperations_ShouldCalculateCorrectly() {
+            // Given
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(pointsConfig.getBaseCost()).thenReturn(1);
+            when(pointsConfig.getMultiplierReview()).thenReturn(3);
+            when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+            // When - Perform mixed operations
+            userStatsService.incrementLabsSolved(1L);    // -1 point, labs_solved: 6, balance: 9
+            userStatsService.incrementLabsReviewed(1L);  // +3 points, labs_reviewed: 4, balance: 12
+            userStatsService.incrementLabsSolved(1L);    // -1 point, labs_solved: 7, balance: 11
+
+            // Then
+            assertThat(testUser.getLabsSolved()).isEqualTo(7); // 5 + 2
+            assertThat(testUser.getLabsReviewed()).isEqualTo(4); // 3 + 1
+            assertThat(testUser.getBalance()).isEqualTo(11); // 10 - 1 + 3 - 1
+            verify(userRepository, times(3)).save(testUser);
+        }
+    }
+} 


### PR DESCRIPTION
**Points system:**
- [x] New User fields: `labs_solved`, `labs_reviewed`, `balance`
- [x] Two gRPC methods in Users Service to increment solved and reviewed counters (separate methods)
- [x] Balance is incremented by `k` * `n` when lab is reviewed by the user and decremented by `n` when lab is solved by the user with initial balance `m`. For now `k` = 3, `n` = 1, `m` = 10. 
- [x] No connections with labs yet, just methods to do operations with counters and balance

**Docker fix:**
- [x] Fix Dockerfiles of labs and ml services so they become insensitive to platform's endings (Linux `LF` was replaced by `CRLF` on Windows in `.sh` scripts which caused not finding scripts on containers start)