### PR TITLE
GetLabsCount & GetSubmissionsCount gRPC endpoints

### DIFF
--- a/services/api-gateway/src/main/proto/labs_service.proto
+++ b/services/api-gateway/src/main/proto/labs_service.proto
@@ -15,6 +15,7 @@ service LabService {
   rpc DeleteLab (DeleteLabRequest) returns (DeleteLabResponse);
 
   rpc GetLabsByUserId (GetLabsByUserIdRequest) returns (LabList);
+  rpc GetLabsCount(GetLabsCountRequest) returns (GetLabsCountResponse);
 
   // Assets Management
   rpc UploadAsset (stream UploadAssetRequest) returns (Asset);
@@ -61,6 +62,12 @@ message GetLabsByUserIdRequest {
   int64 user_id = 1;
   int32 page_number = 2;
   int32 page_size = 3;
+}
+
+message GetLabsCountRequest {}
+
+message GetLabsCountResponse {
+  int32 total_count = 1;
 }
 
 message LabList {

--- a/services/api-gateway/src/main/proto/submissions_service.proto
+++ b/services/api-gateway/src/main/proto/submissions_service.proto
@@ -16,6 +16,7 @@ service SubmissionService {
   // Retrieve submissions for a specific user
   rpc GetUsersSubmissions (GetUsersSubmissionsRequest) returns (SubmissionList);
   rpc GetPossibleToReviewSubmissions (GetPossibleToReviewSubmissionsRequest) returns (SubmissionList);
+  rpc GetSubmissionsCount(GetSubmissionsCountRequest) returns (GetSubmissionsCountResponse);
 
   // Assets Management
   rpc UploadAsset (stream UploadAssetRequest) returns (Asset);
@@ -88,6 +89,12 @@ message GetPossibleToReviewSubmissionsRequest {
   int64 user_id = 1;
   int32 page_number = 2;
   int32 page_size = 3;
+}
+
+message GetSubmissionsCountRequest {}
+
+message GetSubmissionsCountResponse {
+  int32 total_count = 1;
 }
 
 // Assets Management

--- a/services/labs-service/app/proto/labs_service.proto
+++ b/services/labs-service/app/proto/labs_service.proto
@@ -13,6 +13,7 @@ service LabService {
   rpc DeleteLab (DeleteLabRequest) returns (DeleteLabResponse);
 
   rpc GetLabsByUserId (GetLabsByUserIdRequest) returns (LabList);
+  rpc GetLabsCount(GetLabsCountRequest) returns (GetLabsCountResponse);
 
   // Assets Management
   rpc UploadAsset (stream UploadAssetRequest) returns (Asset);
@@ -59,6 +60,12 @@ message GetLabsByUserIdRequest {
   int64 user_id = 1;
   int32 page_number = 2;
   int32 page_size = 3;
+}
+
+message GetLabsCountRequest {}
+
+message GetLabsCountResponse {
+  int32 total_count = 1;
 }
 
 message LabList {

--- a/services/labs-service/app/proto/submissions_service.proto
+++ b/services/labs-service/app/proto/submissions_service.proto
@@ -14,6 +14,7 @@ service SubmissionService {
   // Retrieve submissions for a specific user
   rpc GetUsersSubmissions (GetUsersSubmissionsRequest) returns (SubmissionList);
   rpc GetPossibleToReviewSubmissions (GetPossibleToReviewSubmissionsRequest) returns (SubmissionList);
+  rpc GetSubmissionsCount(GetSubmissionsCountRequest) returns (GetSubmissionsCountResponse);
 
   // Assets Management
   rpc UploadAsset (stream UploadAssetRequest) returns (Asset);
@@ -86,6 +87,12 @@ message GetPossibleToReviewSubmissionsRequest {
   int64 user_id = 1;
   int32 page_number = 2;
   int32 page_size = 3;
+}
+
+message GetSubmissionsCountRequest {}
+
+message GetSubmissionsCountResponse {
+  int32 total_count = 1;
 }
 
 // Assets Management

--- a/services/labs-service/app/services/labs_service.py
+++ b/services/labs-service/app/services/labs_service.py
@@ -497,6 +497,21 @@ class LabService(labs_service.LabServiceServicer):
 
             return lab_list
 
+    def GetLabsCount(self, request, context) -> labs_stub.GetLabsCountResponse:
+        """
+        Get the total number of labs.
+        """
+
+        self.logger.info(f"GetLabsCount requested")
+
+        with Session(self.engine) as session:
+            stmt = select(func.count(Lab.id))
+            total_count = session.execute(stmt).scalar_one()
+
+            self.logger.info(f"Total count: {total_count}")
+
+            return labs_stub.GetLabsCountResponse(total_count=total_count)
+
 
     # ------- Lab Assets Management -------
     def UploadAsset(self, request_iterator, context) -> labs_stub.Asset:

--- a/services/labs-service/app/services/submissions_service.py
+++ b/services/labs-service/app/services/submissions_service.py
@@ -1,7 +1,7 @@
 # Import downloaded modules
 import grpc
 from sqlalchemy.orm import Session
-from sqlalchemy import select
+from sqlalchemy import select, func
 
 # Import built-in modules
 import os
@@ -464,7 +464,6 @@ class SubmissionService(submissions_service.SubmissionServiceServicer):
 
             return submission_list
 
-    
     def GetPossibleToReviewSubmissions(self, request, context) -> submissions_stub.SubmissionList:
         data: dict = {
             "user_id": request.user_id,
@@ -530,6 +529,20 @@ class SubmissionService(submissions_service.SubmissionServiceServicer):
             self.logger.info(f"Retrieved {len(submissions)} submissions to review for user_id={data['user_id']}")
 
             return submission_list
+
+    def GetSubmissionsCount(self, request, context) -> submissions_stub.GetSubmissionsCountResponse:
+        """
+        Get the total number of submissions.
+        """
+        self.logger.info(f"GetSubmissionsCount requested")
+        
+        with Session(self.postgresql_engine) as session:
+            stmt = select(func.count(Submission.id))
+            total_count = session.execute(stmt).scalar_one()
+
+            self.logger.info(f"Total count: {total_count}")
+
+            return submissions_stub.GetSubmissionsCountResponse(total_count=total_count)
 
     # Assets Management
     def UploadAsset(self, request_iterator, context) -> submissions_stub.Asset:

--- a/services/marimo-service/marimo-manager-service/src/main/proto/labs_service.proto
+++ b/services/marimo-service/marimo-manager-service/src/main/proto/labs_service.proto
@@ -1,5 +1,4 @@
 syntax = "proto3";
-
 option java_multiple_files = true;
 option java_package = "olsh.backend.grpc.labs";
 option java_outer_classname = "LabsServiceProto";
@@ -17,6 +16,7 @@ service LabService {
   rpc DeleteLab (DeleteLabRequest) returns (DeleteLabResponse);
 
   rpc GetLabsByUserId (GetLabsByUserIdRequest) returns (LabList);
+  rpc GetLabsCount(GetLabsCountRequest) returns (GetLabsCountResponse);
 
   // Assets Management
   rpc UploadAsset (stream UploadAssetRequest) returns (Asset);
@@ -63,6 +63,12 @@ message GetLabsByUserIdRequest {
   int64 user_id = 1;
   int32 page_number = 2;
   int32 page_size = 3;
+}
+
+message GetLabsCountRequest {}
+
+message GetLabsCountResponse {
+  int32 total_count = 1;
 }
 
 message LabList {


### PR DESCRIPTION
Closes #292
- [x\] Create GetLabsCount gRPC endpoint in Labs Service
- [x\] Implement rpc GetLabsCount() returns (int32) method
- [x\] Change proto files in Labs Service and API Gateway

---

Closes #293
- [x\] Create GetSubmissionsCount gRPC endpoint in Labs Service
- [x\] Implement rpc GetSubmissionsCount() returns (int32) method
- [x\] Change proto files in Labs Service and API Gateway
