### PR TITLE
Statistics endpoint in api gateway

### DIFF
--- a/services/api-gateway/API_README.md
+++ b/services/api-gateway/API_README.md
@@ -11,16 +11,17 @@ All endpoints require JWT authentication unless specified otherwise.
 ## Agenda
 
 1. [Health Check](#health-check)
-2. [User Service](#user-service)
-3. [Labs Service](#labs-service)
-4. [Tag Service](#tag-service)
-5. [Submissions Service](#submissions-service)
-6. [Comments Service](#comments-service)
-7. [Articles Service](#articles-service)
-8. [Feedback Service](#feedback-service)
-9. [Common Response Codes](#common-response-codes)
-10. [Authentication Headers](#authentication-headers)
-11. [Error Response Format](#error-response-format)
+2. [Statistics](#statistics)
+3. [User Service](#user-service)
+4. [Labs Service](#labs-service)
+5. [Tag Service](#tag-service)
+6. [Submissions Service](#submissions-service)
+7. [Comments Service](#comments-service)
+8. [Articles Service](#articles-service)
+9. [Feedback Service](#feedback-service)
+10. [Common Response Codes](#common-response-codes)
+11. [Authentication Headers](#authentication-headers)
+12. [Error Response Format](#error-response-format)
 
 ---  
 
@@ -52,6 +53,23 @@ Example response:
   "status": "UP"
 }
 ```
+
+## Statistics
+
+You can check the statistics of the system with four main parameters.
+- **Endpoint:** `GET /statistics`
+- **Authentication:** Not Required
+
+**Response:**
+```json
+{
+  "users": 1000,
+  "labs": 200,
+  "articles": 50,
+  "submissions": 500
+}
+```
+
 
 ## User Service
 

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/controller/StatisticsController.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/controller/StatisticsController.java
@@ -1,0 +1,39 @@
+package olsh.backend.api_gateway.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import olsh.backend.api_gateway.dto.response.StatisticsResponse;
+import olsh.backend.api_gateway.service.StatisticsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/statistics")
+@RequiredArgsConstructor
+@CrossOrigin(origins = {"http://localhost:5173", "https://open-labs-share.online"}, allowCredentials = "true",
+        maxAge = 3600)
+@Tag(name = "Statistics", description = "Endpoints for retrieving statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping
+    @Operation(summary = "Get statistics", description = "Retrieves statistics data.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Statistics retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = StatisticsResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Statistics not found")
+    })
+    public ResponseEntity<StatisticsResponse> getStatistics() {
+        StatisticsResponse response = statisticsService.getStatistics();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/dto/response/StatisticsResponse.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/dto/response/StatisticsResponse.java
@@ -1,0 +1,27 @@
+package olsh.backend.api_gateway.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Response object containing statistics about the system")
+public class StatisticsResponse {
+
+    @Schema(description = "Number of users", example = "1000")
+    private Integer users;
+
+    @Schema(description = "Number of labs", example = "50")
+    private Integer labs;
+
+    @Schema(description = "Number of articles", example = "200")
+    private Integer articles;
+
+    @Schema(description = "Number of submissions", example = "5000")
+    private Integer submissions;
+}

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/ArticleServiceClient.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/ArticleServiceClient.java
@@ -2,14 +2,17 @@ package olsh.backend.api_gateway.grpc.client;
 
 import com.google.protobuf.ByteString;
 import io.grpc.Channel;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 import olsh.backend.api_gateway.config.UploadFileConfiguration;
 import olsh.backend.api_gateway.exception.ArticleNotFoundException;
 import olsh.backend.api_gateway.exception.AssetUploadException;
+import olsh.backend.api_gateway.exception.GrpcError;
 import olsh.backend.api_gateway.grpc.proto.ArticleProto.*;
 import olsh.backend.api_gateway.grpc.proto.ArticleServiceGrpc;
 import org.springframework.grpc.client.GrpcChannelFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -123,8 +126,8 @@ public class ArticleServiceClient {
      * Sends metadata about the asset being uploaded.
      *
      * @param requestObserver The StreamObserver to send requests
-     * @param articleId      The ID of the article associated with the asset
-     * @param file           The file being uploaded
+     * @param articleId       The ID of the article associated with the asset
+     * @param file            The file being uploaded
      */
     private void sendMetadata(StreamObserver<UploadAssetRequest> requestObserver, Long articleId, MultipartFile file) {
         UploadAssetMetadata metadata = UploadAssetMetadata.newBuilder()
@@ -145,7 +148,7 @@ public class ArticleServiceClient {
      * Streams the file content in chunks to the gRPC server.
      *
      * @param requestObserver The StreamObserver to send requests
-     * @param file           The file to upload
+     * @param file            The file to upload
      * @return The total number of bytes sent
      * @throws IOException If an error occurs while reading the file
      */
@@ -208,7 +211,7 @@ public class ArticleServiceClient {
         }
     }
 
-/**
+    /**
      * Retrieves a paginated list of articles via gRPC.
      *
      * @param request The request containing pagination details
@@ -297,6 +300,25 @@ public class ArticleServiceClient {
         } catch (Exception e) {
             log.error("Error calling GetAssetByArticleId gRPC for article ID {}: {}", articleId, e.getMessage(), e);
             throw new RuntimeException("Failed to get asset by article ID via gRPC", e);
+        }
+    }
+
+    /**
+     * Retrieves the number of articles via gRPC.
+     *
+     * @return The number of articles
+     * @throws GrpcError if the gRPC call fails
+     */
+    public Integer articlesCount() {
+        log.debug("Calling gRPC GetArticlesCount to retrieve total article count");
+        try {
+            GetArticlesCountResponse response =
+                    blockingStub.getArticlesCount(GetArticlesCountRequest.newBuilder().build());
+            log.debug("Successfully retrieved article count: {}", response.getTotalCount());
+            return response.getTotalCount();
+        } catch (StatusRuntimeException e) {
+            log.error("Error calling GetArticlesCount gRPC: {}", e.getMessage(), e);
+            throw new GrpcError(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus().getCode().name(), e.getMessage());
         }
     }
 

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/LabServiceClient.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/LabServiceClient.java
@@ -52,7 +52,7 @@ public class LabServiceClient {
             return response;
         } catch (StatusRuntimeException e) {
             log.error("Error calling CreateLab gRPC: {}", e.getMessage(), e);
-            throw new GrpcError(HttpStatus.BAD_REQUEST, e.getStatus().getCode().name(), e.getMessage());
+            throw new GrpcError(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus().getCode().name(), e.getMessage());
         }
     }
 
@@ -144,6 +144,24 @@ public class LabServiceClient {
             }
             log.error("Error calling DeleteLab gRPC for ID {}: {}", labId, e.getMessage(), e);
             throw new RuntimeException("Failed to delete lab via gRPC", e);
+        }
+    }
+
+    /**
+     * Retrieves the number of labs using the gRPC service.
+     *
+     * @return Total number of labs
+     * @throws GrpcError if the gRPC call fails
+     */
+    public Integer labCount() {
+        log.debug("Calling gRPC GetLabsCount");
+        try {
+            GetLabsCountResponse response = blockingStub.getLabsCount(GetLabsCountRequest.newBuilder().build());
+            log.debug("Successfully retrieved lab count: {}", response.getTotalCount());
+            return response.getTotalCount();
+        } catch (StatusRuntimeException e) {
+            log.error("Error calling GetLabsCount gRPC: {}", e.getMessage(), e);
+            throw new GrpcError(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus().getCode().name(), e.getMessage());
         }
     }
 
@@ -327,5 +345,7 @@ public class LabServiceClient {
             throw new RuntimeException("Failed to download asset", e);
         }
     }
+
+
 }
 

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/SubmissionServiceClient.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/SubmissionServiceClient.java
@@ -2,15 +2,18 @@ package olsh.backend.api_gateway.grpc.client;
 
 import com.google.protobuf.ByteString;
 import io.grpc.Channel;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 import olsh.backend.api_gateway.config.UploadFileConfiguration;
 import olsh.backend.api_gateway.exception.AssetUploadException;
+import olsh.backend.api_gateway.exception.GrpcError;
 import olsh.backend.api_gateway.exception.LabNotFoundException;
 import olsh.backend.api_gateway.exception.SubmissionNotFoundException;
 import olsh.backend.api_gateway.grpc.proto.SubmissionProto.*;
 import olsh.backend.api_gateway.grpc.proto.SubmissionServiceGrpc;
 import org.springframework.grpc.client.GrpcChannelFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -202,6 +205,20 @@ public class SubmissionServiceClient {
             }
             log.error("Error calling DeleteSubmission gRPC for ID {}: {}", submissionId, e.getMessage(), e);
             throw new RuntimeException("Failed to delete submission via gRPC", e);
+        }
+    }
+
+
+    public Integer submissionsCount() {
+        log.debug("Calling gRPC GetSubmissionsCount gRPC request");
+        try {
+            GetSubmissionsCountRequest request = GetSubmissionsCountRequest.newBuilder().build();
+            GetSubmissionsCountResponse response = blockingStub.getSubmissionsCount(request);
+            log.debug("Successfully retrieved submissions count: {}", response.getTotalCount());
+            return response.getTotalCount();
+        } catch (StatusRuntimeException e){
+            log.error("Error calling GetSubmissionsCount gRPC: {}", e.getMessage(), e);
+            throw new GrpcError(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus().getCode().name(), e.getMessage());
         }
     }
 

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/UserServiceClient.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/grpc/client/UserServiceClient.java
@@ -1,12 +1,15 @@
 package olsh.backend.api_gateway.grpc.client;
 
 import io.grpc.Channel;
+import io.grpc.StatusRuntimeException;
 import lombok.extern.slf4j.Slf4j;
+import olsh.backend.api_gateway.exception.GrpcError;
 import olsh.backend.api_gateway.exception.UserNotFoundException;
 import olsh.backend.api_gateway.grpc.proto.UsersServiceGrpc;
 import olsh.backend.api_gateway.grpc.proto.UsersServiceProto.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.grpc.client.GrpcChannelFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -74,6 +77,18 @@ public class UserServiceClient {
         log.debug("Increment labs reviewed response received for userId: {} with success: {} and message: {}",
                 id, response.getSuccess(), response.getMessage());
         return response;
+    }
+
+    public Integer usersCount() {
+        log.debug("Getting users count via gRPC call to user service");
+        try{
+            GetUsersCountResponse response = userServiceStub.getUsersCount(GetUsersCountRequest.newBuilder().build());
+            log.debug("Users count response received: {}", response.getCount());
+            return response.getCount();
+        } catch (StatusRuntimeException e) {
+            log.error("Error calling GetArticlesCount gRPC: {}", e.getMessage(), e);
+            throw new GrpcError(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus().getCode().name(), e.getMessage());
+        }
     }
 }
 

--- a/services/api-gateway/src/main/java/olsh/backend/api_gateway/service/StatisticsService.java
+++ b/services/api-gateway/src/main/java/olsh/backend/api_gateway/service/StatisticsService.java
@@ -1,0 +1,38 @@
+package olsh.backend.api_gateway.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import olsh.backend.api_gateway.dto.response.StatisticsResponse;
+import olsh.backend.api_gateway.grpc.client.ArticleServiceClient;
+import olsh.backend.api_gateway.grpc.client.LabServiceClient;
+import olsh.backend.api_gateway.grpc.client.SubmissionServiceClient;
+import olsh.backend.api_gateway.grpc.client.UserServiceClient;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class StatisticsService {
+
+    private final UserServiceClient userServiceClient;
+    private final LabServiceClient labServiceClient;
+    private final ArticleServiceClient articleServiceClient;
+    private final SubmissionServiceClient submissionServiceClient;
+
+
+    public StatisticsResponse getStatistics() {
+        log.info("Fetching statistics from all services");
+        Integer usersCount = userServiceClient.usersCount();
+        Integer labsCount = labServiceClient.labCount();
+        Integer articlesCount = articleServiceClient.articlesCount();
+        Integer submissionsCount = submissionServiceClient.submissionsCount();
+        StatisticsResponse response = StatisticsResponse.builder()
+                .users(usersCount)
+                .labs(labsCount)
+                .articles(articlesCount)
+                .submissions(submissionsCount)
+                .build();
+        log.debug("Statistics response: {}", response);
+        return response;
+    }
+}


### PR DESCRIPTION
Done:

- [x] Implement statistics endpoint in API Gateway
- [x] Return number of: users, submissions, labs, articles
- [x] Update README with new functionality

Usage:
- **Endpoint:** `GET /statistics`
- **Authentication:** Not Required

**Response:**
```json
{
  "users": 1000,
  "labs": 200,
  "articles": 50,
  "submissions": 500
}
```